### PR TITLE
Added back CMD command

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/production/aws/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.io/amazon/aws-cli:2.17.0
 
 # Clear entrypoint from the base image, otherwise it's always calling the aws CLI
 ENTRYPOINT []
+CMD ["/bin/bash"]
 
 COPY ./compose/production/aws/maintenance /usr/local/bin/maintenance
 COPY ./compose/production/postgres/maintenance/_sourced /usr/local/bin/maintenance/_sourced


### PR DESCRIPTION
Commit 634b091756a6e8e2731b8cd610299972f716c89c introduced an issue. Clearning the ENTRYPOINT also clears the CMD. We need to set explicitly CMD again.

## Description

Set CMD in derived Dockerfile (use same CMD as original Amazon aws-cli container).

Checklist:

- [ X] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ X] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

Fix #5241